### PR TITLE
Improving gen-files-json.py script for multiplatform compatibilty and also reduce unneeded file inclusion

### DIFF
--- a/bin/gen-files-json.py
+++ b/bin/gen-files-json.py
@@ -1,21 +1,35 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os, json
+"""This script walks about our app directory hierarchy and collects all _wanted_ and _needed_ python files.
+
+This should work for all of Linux, MacOS and Windows and uses posix compliant path structure.
+"""
+
+
+import json
+import os
+from pathlib import Path
 
 files = []
 
 walkObj = os.walk(".")
 for root, dirnames, filenames in walkObj:
 	for f in filenames:
-		if (f.endswith(".py")
-			and not "(" in f
-			and not any([f.startswith(i) for i in ["get-", "gen-", "test-"]])):
-
-			f = os.path.join(root, f)[2:]
-			files.append(f)
+		pathObject = Path(root).joinpath(f)
+		pathParts = pathObject.parts
+		if (f.endswith(".py") and
+				"(" not in f and
+				not any([f.startswith(i) for i in ["get-", "gen-", "test-"]]) and
+				"docs" not in pathParts and  # dont want flare/docs in files
+				"examples" not in pathParts and  # dont want flare/examples in files
+				"scripts" not in pathParts and  # dont want flare/scripts in files
+				"test" not in pathParts  # dont want flare/test in files
+		):
+			f = pathObject.as_posix().rstrip("./")
 			print(f)
+			files.append(f)
 
-with open("files.json", "w") as f:
-	json.dump(sorted(files), f, indent=2)
-	print("", file=f)  # append line break
+with open("files.json", "w") as outputFile:
+	json.dump(sorted(files), outputFile, indent=2)
+	print("", file=outputFile)  # append line break


### PR DESCRIPTION
* simple script documentation
* switched to pathlib.Path for platform independent files.json generation especially for windows to be posix compliant
* do not include files in examples, docs and scripts subfolder of flare

We could also make exclusion configurable via argparse for fine grained exclusion (patterns)...